### PR TITLE
Show remote carets

### DIFF
--- a/widget/css/main.css
+++ b/widget/css/main.css
@@ -30,3 +30,8 @@
 .remoteSelection {
   background-color: #3f5d38;
 }
+
+.remoteCaret {
+  background-color: #7fb971;
+  width: 1px;
+}


### PR DESCRIPTION
Here we go. I tried to follow your codestyle, I guess it should be ok. The changes provided should cover every input from peers (multiple carets, removals, additions, pastes and cuts)

If this PR's alright, then in the future I guess we should create a html template for carets (for future features such as displaying the carets owner name and for code maintenance purposes)

This solves #22 