### PR TITLE
Less intrusive tooltips

### DIFF
--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -5,8 +5,12 @@ define(function (require, exports, module) {
       require("text!../widget/html/tooltip.html"),
       { "Message": message}))
     
+    $el.hide()
+    
     setTimeout(function () {
-      $el.remove()
+      $el.fadeOut(200, function () {
+        $el.remove()
+      })
     }, 4000)
     return $el
   }

--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -1,0 +1,17 @@
+define(function (require, exports, module) {
+  
+  var create = function (message) {
+    var $el = $(Mustache.render(
+      require("text!../widget/html/tooltip.html"),
+      { "Message": message}))
+    
+    setTimeout(function () {
+      $el.remove()
+    }, 4000)
+    return $el
+  }
+  
+  module.exports = {
+    create: create
+  }
+})

--- a/main.js
+++ b/main.js
@@ -522,6 +522,8 @@ define(function (require, exports, module) {
     
       $tooltip.css('top', $(button).offset().top + "px")
       $tooltip.css('right', $('#main-toolbar').width())
+    
+      $tooltip.fadeIn(200)
       
       $(document.body).prepend($tooltip)
   }

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ define(function (require, exports, module) {
 
   var RemoteManager = require('./lib/remote')
   var PeerGraph = require('./lib/npm/p2p-graph')
+  var Tooltip = require('./lib/tooltip')
 
   var remote = null
   var isSyncing = false
@@ -517,12 +518,12 @@ define(function (require, exports, module) {
   function handleLostPeer(peer) {
     if (!isSyncing) return
     
-    Dialogs.showModalDialog(
-      '', 
-      'Multihack', 
-      '<p>Your connection to "'+peer.metadata.nickname+'" was lost.</p>', 
-      [customButton('Ok')]
-    )
+      var $tooltip = Tooltip.create('Your connection to "' + peer.metadata.nickname + '" was lost.')
+    
+      $tooltip.css('top', $(button).offset().top + "px")
+      $tooltip.css('right', $('#main-toolbar').width())
+      
+      $(document.body).prepend($tooltip)
   }
   
   function handleRemoteDeleteFile (data) {

--- a/widget/html/tooltip.html
+++ b/widget/html/tooltip.html
@@ -1,0 +1,6 @@
+<div class="tooltip fade left in">
+  <div class="tooltip-arrow"></div>
+  <div class="tooltip-inner">
+    {{ Message }} 
+  </div>
+</div>


### PR DESCRIPTION
This solves #26 .

I didn't find a way of accessing the function that creates those tooltips mentioned in the ticket, so I simply used the same markup and classes. Currently the tooltip hides after 4s and is positioned next to the multihack's button on the brackets `#main-toolbar`.

[See how it looks](https://i.imgur.com/i3JmCbS.png)